### PR TITLE
Update CloudinaryAdapter.php

### DIFF
--- a/src/CloudinaryAdapter.php
+++ b/src/CloudinaryAdapter.php
@@ -314,7 +314,7 @@ class CloudinaryAdapter implements FilesystemAdapter
                         $resource["resource_type"] === "raw"
                             ? $resource["public_id"]
                             : $resource["public_id"] . "." . $resource["format"];
-                    if ($this->dynamicFolders && $resource["asset_folder"] !== "") {
+                    if ($this->dynamicFolders && isset($resource["asset_folder"]) && $resource["asset_folder"] !== "") {
                         $path = $resource["asset_folder"] . "/" . $path;
                     }
                     $path = $this->prefixer->stripPrefix($path);


### PR DESCRIPTION
Hi there! Thank you so much for your effort on this package!

I'm currently integrating Cloudinary as external FS in Craft CMS and it works great so far. 

However, in one case, when re-indexig the assets, the following error is thrown: `Undefined array key "asset_folder" at /vendor/thomasvantuycom/flysystem-cloudinary/src/CloudinaryAdapter.php:317`.

I haven't verified it, but possibly somwthing like this change may help? Thanks a lot!