### PR TITLE
Unable to delete folders

### DIFF
--- a/src/CloudinaryAdapter.php
+++ b/src/CloudinaryAdapter.php
@@ -206,6 +206,8 @@ class CloudinaryAdapter implements FilesystemAdapter
                 }
             }
             $this->client->adminApi()->deleteFolder($path);
+        } catch (NotFound $e) {
+            // Silently fail when the remote folder did not exist?
         } catch (Throwable $e) {
             throw UnableToDeleteDirectory::atLocation($path, $e->getMessage(), $e);
         }
@@ -396,7 +398,7 @@ class CloudinaryAdapter implements FilesystemAdapter
                 }
             }
             if ($newPublicId === $publicId) {
-                $this->client->adminApi()->update($publicId, $options);        
+                $this->client->adminApi()->update($publicId, $options);
             } else {
                 $this->client->uploadApi()->rename($publicId, $newPublicId, $options);
             }

--- a/src/CloudinaryAdapter.php
+++ b/src/CloudinaryAdapter.php
@@ -337,7 +337,11 @@ class CloudinaryAdapter implements FilesystemAdapter
                         $filesize,
                         $visibility,
                         $lastModified,
-                        $mimeType
+                        $mimeType,
+                        extraMetadata: [
+                            'public_id' => $resource["public_id"],
+                            'asset_folder' => $resource["asset_folder"],
+                        ]
                     );
                 }
             } while (isset($response["next_cursor"]));


### PR DESCRIPTION
Hi @thomasvantuycom,

I would like to take this opportunity to thank you again for your work on this library! 😌 I'm still using it in a Craft 4 project (with version 1 of the Craft integration) to store craft assets in Cloudinary, using dynamic folders. I've encountered a few issues lately that I'm trying to resolve myself, but i may open separate GitHub issues regarding them.

One situation i'd like to ask for your help or input is the following:
Assuming a folder is deleted on Cloudinary but not the local Craft filesystem, i'd try to re-index the assets — and in the next step delete the local assets and folders that are not in Cloudinary. However, deleting a folder that doesn't exist in Cloudinary fails for that reason; and consequently is not deleted locally, resulting in the inability to keep the filesystem in sync.

Are you able to reproduce this?

I'm not sure about how to ideally solve this. Here i've experimented with simply not throwing an error if a folder that is being deleted is not found in Cloudinary. Do you think that's safe to do or will it have any consequences in other cases?

Thanks!