### PR TITLE
Fix: deleting inexistent folders

### DIFF
--- a/src/CloudinaryAdapter.php
+++ b/src/CloudinaryAdapter.php
@@ -420,7 +420,11 @@ class CloudinaryAdapter implements FilesystemAdapter, PublicUrlGenerator
             $fileSize,
             $visibility,
             $lastModified,
-            $mimeType
+            $mimeType,
+            extraMetadata: [
+                'public_id' => $resource["public_id"],
+                'asset_folder' => $resource["asset_folder"],
+            ],
         );
     }
 

--- a/src/CloudinaryAdapter.php
+++ b/src/CloudinaryAdapter.php
@@ -161,6 +161,8 @@ class CloudinaryAdapter implements FilesystemAdapter, PublicUrlGenerator
             }
 
             $this->client->adminApi()->deleteFolder($path);
+        } catch (NotFound $e) {
+            // Silently fail when the remote folder did not exist?
         } catch (Throwable $e) {
             throw UnableToDeleteDirectory::atLocation($path, $e->getMessage(), $e);
         }

--- a/src/CloudinaryAdapter.php
+++ b/src/CloudinaryAdapter.php
@@ -161,7 +161,7 @@ class CloudinaryAdapter implements FilesystemAdapter, PublicUrlGenerator
             }
 
             $this->client->adminApi()->deleteFolder($path);
-        } catch (NotFound $e) {
+        } catch (UnableToListContents $e) {
             // Silently fail when the remote folder did not exist?
         } catch (Throwable $e) {
             throw UnableToDeleteDirectory::atLocation($path, $e->getMessage(), $e);


### PR DESCRIPTION
This is #3 again; as i'm still experiencing the same error.

Here are the steps to reproduce it:
1. Create a folder in Craft (& Cloudinary).
2. Delete the folder in Cloudinary, without triggering a webhook to delete the folder in craft as well.
3. The folder now exists in Craft but not Cloudinary. Deleting the folder in Craft now fails.